### PR TITLE
Fix RELEASE_VERSION on tag

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,7 +5,7 @@ BUILD_CMD="./gradlew --console=plain --no-daemon clean assemble"
 
 if [ "${GIT_TAG}" ]
 then
-  RELEASE_VERSION=${GIT_TAG}-onecloud
+  RELEASE_VERSION=${GIT_TAG}
 	echo "Detected tagged build version ${GIT_TAG}. Setting version to ${RELEASE_VERSION}"
 	BUILD_CMD+=" -Dorg.gradle.project.version=${RELEASE_VERSION}"
 else


### PR DESCRIPTION
## Purpose
- RM checks the version of our deployed artifacts to ensure it matches the version going through pipeline. This check is [failing](https://w-rmconsole.appspot.com/release/flip-tables%201.1.2-1/pipeline/#6580422665043968) on 1.1.2-1 due to `onecloud` being appended to the end of the version number.

## Solution

- Remove `onecloud` from the build versioning to allow RM checks to succeed.
- Because Workiva publishes artifacts to a private repository, should not cause conflicts with external versions
- Downstream consumers will need to ensure the Workiva version is specified when pulling dependencies

## Semantic Versioning (check one)

- [ ] The following were changed in a non-backward compatible way and requires a major version bump:
    - *[link to the breaking change in the diff]*
- [ ] Something public was added or changed in backward compatible way, this requires a minor version bump
- [ ] No public changes nor new features (backwards-compatible refactor or bug fix), so this can be included in a patch
  release

## How to QA

- [ ] run the following related examples: **(fill in)**
- [ ] Other necessary steps needed to fully exercise the solution should be added here. **(fill in)**
